### PR TITLE
Fallbacks for Mozilla and Webkit browsers

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,6 @@
 var CSSCurssors = CSSCurssors || {};
 
-window.onload = function() {
+window.onload = function() { 
 	CSSCurssors.loadCursors();
 }
 
@@ -10,7 +10,7 @@ window.onload = function() {
  * Encapsules the different cursor properties in CSS along with browser that support the property
  * in an array of JSON.
  *
- * an entry needs 'name' property to get displayed, other properties are optional if no  value for browser
+ * an entry needs 'name' property to get displayed, other properties are optional if no  value for browser 
  * is set the browser will be indicated as not supported.
  */
 
@@ -125,11 +125,11 @@ CSSCurssors.createNode = function(cursorData, end ) {
 			browserSupport += '<li ><i class="fa fa-edge"></i></li>';
 		}
 
-		newCursorNode.innerHTML = '<div class="description-wrap" style="cursor: -moz-'+ cursorData['name'] +'; cursor: -webkit-'+ cursorData['name'] +'; cursor:'+ cursorData['name'] +';" ><div class="description"><div class="holder">Cursor : ' + cursorData['name']   + '<br/></div></div></div> <ul class="browserSupport">' + browserSupport + '</ul>';
+		newCursorNode.innerHTML = '<div class="description-wrap" style="cursor: -moz-'+ cursorData['name'] +'; cursor: -webkit-'+ cursorData['name'] +'; cursor:'+ cursorData['name'] +'" ><div class="description"><div class="holder">Cursor : ' + cursorData['name']   + '<br/></div></div></div> <ul class="browserSupport">' + browserSupport + '</ul>';
 		return newCursorNode;
 
 	} else {
 		return 0;
 	}
-
+	
 }

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,6 @@
 var CSSCurssors = CSSCurssors || {};
 
-window.onload = function() { 
+window.onload = function() {
 	CSSCurssors.loadCursors();
 }
 
@@ -10,7 +10,7 @@ window.onload = function() {
  * Encapsules the different cursor properties in CSS along with browser that support the property
  * in an array of JSON.
  *
- * an entry needs 'name' property to get displayed, other properties are optional if no  value for browser 
+ * an entry needs 'name' property to get displayed, other properties are optional if no  value for browser
  * is set the browser will be indicated as not supported.
  */
 
@@ -125,11 +125,11 @@ CSSCurssors.createNode = function(cursorData, end ) {
 			browserSupport += '<li ><i class="fa fa-edge"></i></li>';
 		}
 
-		newCursorNode.innerHTML = '<div class="description-wrap" style="cursor:'+ cursorData['name'] +'" ><div class="description"><div class="holder">Cursor : ' + cursorData['name']   + '<br/></div></div></div> <ul class="browserSupport">' + browserSupport + '</ul>';
+		newCursorNode.innerHTML = '<div class="description-wrap" style="cursor: -moz-'+ cursorData['name'] +'; cursor: -webkit-'+ cursorData['name'] +'; cursor:'+ cursorData['name'] +';" ><div class="description"><div class="holder">Cursor : ' + cursorData['name']   + '<br/></div></div></div> <ul class="browserSupport">' + browserSupport + '</ul>';
 		return newCursorNode;
 
 	} else {
 		return 0;
 	}
-	
+
 }


### PR DESCRIPTION
I noticed that 'grab' and 'grabbing' didn't work on Chrome. They need the -webkit- browser prefix in order to work.

I added these prefixes as fallbacks like they do in the MDN docs: https://developer.mozilla.org/en-US/docs/Web/CSS/cursor 
