### PR TITLE
Fix font usage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 
 body{
-	font-family: "Merriweather Sans";
+	font-family: "Merriweather";
 	font-weight: 100;
 }
 


### PR DESCRIPTION
In following what you say in the [README.md](README.md) file, _Merriweather Sans_ is for heading and _Merriweather_ for body.
